### PR TITLE
plot: fix legend overflow

### DIFF
--- a/docs/notes/Notes_v0.2.1.md
+++ b/docs/notes/Notes_v0.2.1.md
@@ -1,0 +1,9 @@
+# v0.2.1
+
+## New
+
+- Issue #10, PR #34 | Add documentation for Conda installation.
+
+## Fixes
+
+- Issue #27, PR TBD | Fix legend overflow in plot.

--- a/src/plot/mod.rs
+++ b/src/plot/mod.rs
@@ -268,16 +268,19 @@ pub fn create(
         .ok_or_else(|| eyre!("Failed to calculated the maximum coord length"))?;
 
     // longest legend label (in pixels)
-    // longest legend label (in pixels)
     let default_labels =
-        vec!["Reference", "Private"].into_iter().map(String::from).collect_vec();
+        vec!["Reference", "Private Mutation"].into_iter().map(String::from).collect_vec();
 
     let longest_legend_label = parents
         .iter()
-        .chain(default_labels.iter())
+        .chain(default_labels.clone().iter())
         .map(|id| {
+            let label = match default_labels.contains(id) {
+                true => id.to_string(),
+                false => format!("{id} Reference"),
+            };
             text::to_image(
-                &format!("{id} Reference"),
+                &label,
                 constants::FONT_REGULAR,
                 constants::FONT_SIZE,
                 &constants::TEXT_COLOR,

--- a/src/plot/mod.rs
+++ b/src/plot/mod.rs
@@ -268,8 +268,13 @@ pub fn create(
         .ok_or_else(|| eyre!("Failed to calculated the maximum coord length"))?;
 
     // longest legend label (in pixels)
+    // longest legend label (in pixels)
+    let default_labels =
+        vec!["Reference", "Private"].into_iter().map(String::from).collect_vec();
+
     let longest_legend_label = parents
         .iter()
+        .chain(default_labels.iter())
         .map(|id| {
             text::to_image(
                 &format!("{id} Reference"),


### PR DESCRIPTION
- Fix plot overflow for issue #27, where the new label "Private Mutation" would sometimes overlap the legend border.
- Simply added "Private Mutation" to the list of default labels to check the length.

![image](https://github.com/phac-nml/rebar/assets/14981272/08fb137b-3b87-4333-8941-31a54b8fa4af)