### PR TITLE
ci: restrict artifact uploads in test and nightly

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -39,7 +39,7 @@ jobs:
       binary: ${{ matrix.binary }}
 
   # ---------------------------------------------------------------------------
-  latest:
+  nightly:
 
     needs: compile
 
@@ -88,7 +88,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: validate-${{ matrix.arch }}
-          path: output/sars-cov-2/nightly/validate
+          name: validate-linelist_${{ matrix.arch }}
+          path: output/sars-cov-2/nightly/validate/linelist.tsv
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -151,6 +151,10 @@ jobs:
         if: always()
         with:
           name: output-${{ matrix.arch }}
-          path: output
+          path: |
+            output/alignment
+            output/toy1
+            output/populations/linelist.tsv
+
           if-no-files-found: error
           retention-days: 7


### PR DESCRIPTION
- Resolves #29 
- The Nightly CI job will only update the validation linelist, not all the plots, because that consumes too much artifact space.