### PR TITLE
parsimony: change coordinates from vec to slice

### DIFF
--- a/src/dataset/mod.rs
+++ b/src/dataset/mod.rs
@@ -141,7 +141,7 @@ impl Dataset {
         &self,
         sequence: &Sequence,
         populations: Option<&Vec<&String>>,
-        coordinates: Option<&Vec<usize>>,
+        coordinates: Option<&[usize]>,
     ) -> Result<SearchResult, Report> {
         // initialize an empty result, this will be the final product of this function
         let mut result = SearchResult::new(sequence);

--- a/src/sequence/parsimony.rs
+++ b/src/sequence/parsimony.rs
@@ -30,7 +30,7 @@ impl Summary {
     pub fn from_sequence(
         sequence: &Sequence,
         query: &Sequence,
-        coordinates: Option<&Vec<usize>>,
+        coordinates: Option<&[usize]>,
     ) -> Result<Self, Report> {
         let mut parsimony_summary = Summary::new();
 


### PR DESCRIPTION
- Resolves Issue #23 
In `parsimony::from_sequence`, change `coordinates` type from Vector to Slice.